### PR TITLE
Adding routing_mode field to ci director.yml

### DIFF
--- a/concourse/gcp/director.yml
+++ b/concourse/gcp/director.yml
@@ -9,3 +9,4 @@ tags:
   - "no-ip"
   - internal
 zone: us-east4-a
+routing_mode: cf

--- a/concourse/vsphere/director.yml
+++ b/concourse/vsphere/director.yml
@@ -3,6 +3,7 @@ internal_cidr: 10.74.34.0/25
 internal_gw: 10.74.34.1
 internal_ip: 10.74.34.123
 network_name: calgary
+routing_mode: cf
 
 vcenter_cluster: canada # vCenter Cluster
 vcenter_dc: canada-dc # vCenter Datacenter Name


### PR DESCRIPTION
routing_mode will be required once [PR #101](https://github.com/pivotal-cf-experimental/kubo-deployment/pull/101) is merged inkubo-deployment. It won't hurt to add it before that PR is merged.