### PR TITLE
Test dashboard is accessible via kubectl proxy

### DIFF
--- a/src/integration-tests/generic/kubectl_test.go
+++ b/src/integration-tests/generic/kubectl_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Kubectl", func() {
 
 	It("Should provide access to the dashboard", func() {
 		session := runner.RunKubectlCommand("proxy")
-		panic(Eventually(session).Should(gbytes.Say("Starting to serve on")))
+		Eventually(session).Should(gbytes.Say("Starting to serve on"))
 
 		timeout := time.Duration(5 * time.Second)
 		httpClient := http.Client{

--- a/src/integration-tests/generic/kubectl_test.go
+++ b/src/integration-tests/generic/kubectl_test.go
@@ -3,8 +3,12 @@ package generic_test
 import (
 	"integration-tests/test_helpers"
 
+	"net/http"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 )
 
@@ -29,6 +33,28 @@ var _ = Describe("Kubectl", func() {
 		session := runner.RunKubectlCommand("run", podName, "--image", "pcfkubo/alpine:stable", "--restart=Never", "--image-pull-policy=Always", "-ti", "--rm", "--", "kubectl", "get", "services")
 		session.Wait(120)
 		Expect(session).To(gexec.Exit(0))
+	})
+
+	It("Should provide access to the dashboard", func() {
+		session := runner.RunKubectlCommand("proxy")
+		panic(Eventually(session).Should(gbytes.Say("Starting to serve on")))
+
+		timeout := time.Duration(5 * time.Second)
+		httpClient := http.Client{
+			Timeout: timeout,
+		}
+
+		appUrl := "http://127.0.0.1:8001/ui/"
+
+		Eventually(func() int {
+			result, err := httpClient.Get(appUrl)
+			if err != nil {
+				return -1
+			}
+			return result.StatusCode
+		}, "120s", "5s").Should(Equal(200))
+
+		session.Terminate()
 	})
 
 })


### PR DESCRIPTION
[#148375471]

Signed-off-by: Konstantin Semenov <ksemenov@pivotal.io>